### PR TITLE
ST-24: Add major autocomplete dropdown to signup form

### DIFF
--- a/packages/frontend/src/components/MajorComboBox.tsx
+++ b/packages/frontend/src/components/MajorComboBox.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import "./Styles/InputField.css";
+import "./Styles/MajorComboBox.css";
+
+interface MajorComboBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const MAJORS = [
+  "Aerospace Engineering",
+  "Agricultural Business",
+  "Agricultural Communication",
+  "Agricultural Science",
+  "Agricultural Systems Management",
+  "Animal Science",
+  "Anthropology and Geography",
+  "Architectural Engineering",
+  "Architecture",
+  "Art and Design",
+  "Biochemistry",
+  "Biological Sciences",
+  "Biomedical Engineering",
+  "BioResource and Agricultural Engineering",
+  "Business Administration",
+  "Chemistry",
+  "Child Development",
+  "City and Regional Planning",
+  "Civil Engineering",
+  "Communication Studies",
+  "Comparative Ethnic Studies",
+  "Computer Engineering",
+  "Computer Science",
+  "Construction Management",
+  "Dairy Science",
+  "Economics",
+  "Electrical Engineering",
+  "English",
+  "Environmental Earth and Soil Sciences",
+  "Environmental Engineering",
+  "Environmental Management and Protection",
+  "Experience and Event Management",
+  "Facilities Engineering Technology",
+  "Food Science",
+  "Forest and Fire Sciences",
+  "General Engineering",
+  "Graphic Communication",
+  "History",
+  "Industrial Engineering",
+  "Industrial Technology and Packaging",
+  "Interdisciplinary Studies",
+  "International Strategy and Security",
+  "Journalism",
+  "Kinesiology",
+  "Landscape Architecture",
+  "Liberal Arts and Engineering Studies",
+  "Liberal Studies",
+  "Manufacturing Engineering",
+  "Marine Engineering Technology",
+  "Marine Sciences",
+  "Marine Transportation",
+  "Materials Engineering",
+  "Mathematics",
+  "Mechanical Engineering",
+  "Microbiology",
+  "Music",
+  "Nutrition",
+  "Oceanography",
+  "Philosophy",
+  "Physics",
+  "Plant Sciences",
+  "Political Science",
+  "Psychology",
+  "Public Health",
+  "Sociology",
+  "Software Engineering",
+  "Spanish",
+  "Statistics",
+  "Theatre Arts",
+  "Wine and Viticulture"
+];
+
+export default function MajorComboBox({ value, onChange }: MajorComboBoxProps) {
+  const [isFocused, setIsFocused] = useState(false);
+  const [inputText, setInputText] = useState(value);
+  const [selectedMajor, setSelectedMajor] = useState(value);
+  const isClearingSelectionFromInput = useRef(false);
+
+  useEffect(() => {
+    if (isClearingSelectionFromInput.current && value === "") {
+      isClearingSelectionFromInput.current = false;
+      setSelectedMajor("");
+      return;
+    }
+
+    isClearingSelectionFromInput.current = false;
+    setInputText(value);
+    setSelectedMajor(value);
+  }, [value]);
+
+  const filteredMajors = useMemo(() => {
+    const query = inputText.trim().toLowerCase();
+
+    if (!query) {
+      return MAJORS;
+    }
+
+    return MAJORS.filter((major) => major.toLowerCase().includes(query));
+  }, [inputText]);
+
+  const showDropdown = isFocused && filteredMajors.length > 0;
+
+  return (
+    <div className="input-container major-combobox">
+      <label className="input-label">Major</label>
+
+      <input
+        className="input-input"
+        value={inputText}
+        type="text"
+        onKeyDown={(event) => {
+          if (event.key !== "Tab" || !showDropdown) {
+            return;
+          }
+
+          const firstMatch = filteredMajors[0];
+
+          event.preventDefault();
+          setInputText(firstMatch);
+          setSelectedMajor(firstMatch);
+          onChange(firstMatch);
+          setIsFocused(false);
+        }}
+        onChange={(event) => {
+          setInputText(event.target.value);
+          if (selectedMajor) {
+            setSelectedMajor("");
+          }
+          isClearingSelectionFromInput.current = true;
+          onChange("");
+          setIsFocused(true);
+        }}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+      />
+
+      {showDropdown && (
+        <div className="major-combobox-dropdown">
+          {filteredMajors.map((major) => (
+            <div
+              className="major-combobox-option"
+              key={major}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                setInputText(major);
+                setSelectedMajor(major);
+                onChange(major);
+                setIsFocused(false);
+              }}>
+              {major}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/MajorComboBox.tsx
+++ b/packages/frontend/src/components/MajorComboBox.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import "./Styles/InputField.css";
-import "./Styles/MajorComboBox.css";
+import "./styles/InputField.css";
+import "./styles/MajorComboBox.css";
 
 interface MajorComboBoxProps {
   value: string;

--- a/packages/frontend/src/components/styles/MajorComboBox.css
+++ b/packages/frontend/src/components/styles/MajorComboBox.css
@@ -1,0 +1,26 @@
+.major-combobox {
+  position: relative;
+}
+
+.major-combobox-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  max-height: 320px;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+.major-combobox-option {
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.major-combobox-option:hover {
+  background: #f0f0f0;
+}

--- a/packages/frontend/src/pages/SignupPage.tsx
+++ b/packages/frontend/src/pages/SignupPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import InputField from "../components/InputField";
+import MajorComboBox from "../components/MajorComboBox";
 import NavLink from "../components/NavLink";
 import InformationSection from "../components/InformationSection";
 import FormContainer from "../components/FormContainer";
@@ -31,6 +32,11 @@ function SignupPage() {
       campus: campus,
       major: major
     };
+    if (!major) {
+      toast.error("Please select a major from the list.");
+      return;
+    }
+
     if (!email.endsWith("@calpoly.edu")) {
       toast.error("Please use a valid Cal Poly email");
       return;
@@ -98,13 +104,7 @@ function SignupPage() {
 
             <div className="field-container">
               <div className="user-field">
-                <InputField
-                  value={major}
-                  label="Major"
-                  type="text"
-                  placeHolder="Your Major"
-                  onChange={(e) => setMajor(e.target.value)}
-                />
+                <MajorComboBox value={major} onChange={setMajor} />
               </div>
 
               <div className="user-field">


### PR DESCRIPTION
Replaces the plain text major input on the signup form with an autocomplete combobox. Shows all Cal Poly majors on focus, filters as you type, and supports Tab to autofill the first match. Submission is blocked if no valid major is selected from the list.