### PR TITLE
St 19 20/bug fixes

### DIFF
--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/controller/ReportController.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/controller/ReportController.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,25 +17,25 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ServiceMarketplace.service_marketplace.model.Report;
 import com.ServiceMarketplace.service_marketplace.model.User;
 import com.ServiceMarketplace.service_marketplace.repository.ReportRepository;
-import com.ServiceMarketplace.service_marketplace.repository.UserRepository;
+import com.ServiceMarketplace.service_marketplace.service.UserService;
 
 @RestController
 @RequestMapping("/api/reports")
 public class ReportController {
 
     private final ReportRepository reportRepository;
-    private final UserRepository userRepository;
+    private final UserService userService;
 
-    public ReportController(ReportRepository reportRepository, UserRepository userRepository) {
+    public ReportController(ReportRepository reportRepository, UserService userService) {
         this.reportRepository = reportRepository;
-        this.userRepository = userRepository;
+        this.userService = userService;
     }
 
     @PostMapping
     public ResponseEntity<Report> createReport(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody CreateReportRequest request) {
-        User reporter = getCurrentUser(userDetails);
+        User reporter = userService.getUserByEmail(userDetails.getUsername());
 
         Report report = new Report();
         report.setReporterId(reporter.getId());
@@ -49,9 +48,7 @@ public class ReportController {
 
     @GetMapping
     public ResponseEntity<List<Report>> getReports(@AuthenticationPrincipal UserDetails userDetails) {
-        User requester = getCurrentUser(userDetails);
-
-        if (!isAdmin(requester)) {
+        if (!userService.isAdmin(userDetails.getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -62,9 +59,7 @@ public class ReportController {
     public ResponseEntity<Report> resolveReport(
             @PathVariable String reportId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        User requester = getCurrentUser(userDetails);
-
-        if (!isAdmin(requester)) {
+        if (!userService.isAdmin(userDetails.getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
@@ -78,15 +73,6 @@ public class ReportController {
         report.setStatus("resolved");
 
         return ResponseEntity.status(HttpStatus.OK).body(reportRepository.save(report));
-    }
-
-    private User getCurrentUser(UserDetails userDetails) {
-        return userRepository.findByEmail(userDetails.getUsername())
-            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-    }
-
-    private boolean isAdmin(User user) {
-        return "admin".equals(user.getRole());
     }
 
     public static record CreateReportRequest(String listingId, String providerId, String reason) {

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/controller/UserController.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/controller/UserController.java
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ServiceMarketplace.service_marketplace.dto.UpdateUserProfileRequest;
 import com.ServiceMarketplace.service_marketplace.dto.UserProfile;
 import com.ServiceMarketplace.service_marketplace.model.User;
-import com.ServiceMarketplace.service_marketplace.repository.UserRepository;
 import com.ServiceMarketplace.service_marketplace.service.UserService;
 
 import jakarta.validation.Valid;
@@ -28,11 +26,9 @@ import jakarta.validation.Valid;
 public class UserController {
 
     private final UserService userService;
-    private final UserRepository userRepository;
 
-    public UserController(UserService userService, UserRepository userRepository){
+    public UserController(UserService userService){
         this.userService = userService;
-        this.userRepository = userRepository;
     }
 
     @GetMapping("/me")
@@ -53,89 +49,43 @@ public class UserController {
 
     @GetMapping
     public ResponseEntity<List<User>> getUsers(@AuthenticationPrincipal UserDetails userDetails) {
-        User requester = getCurrentUser(userDetails);
-
-        if (!isAdmin(requester)) {
+        if (!userService.isAdmin(userDetails.getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        return ResponseEntity.status(HttpStatus.OK).body(userRepository.findAll());
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getAllUsers());
     }
 
     @GetMapping("/{userId}")
     public ResponseEntity<User> getUserById(
             @PathVariable String userId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        User requester = getCurrentUser(userDetails);
-
-        if (!isAdmin(requester)) {
+        if (!userService.isAdmin(userDetails.getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        var user = userRepository.findById(userId);
-
-        if (user.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-
-        return ResponseEntity.status(HttpStatus.OK).body(user.get());
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserById(userId));
     }
 
     @PutMapping("/{userId}/suspend")
-    public ResponseEntity<?> suspendUser(
+    public ResponseEntity<User> suspendUser(
             @PathVariable String userId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        User requester = getCurrentUser(userDetails);
-
-        if (!isAdmin(requester)) {
+        if (!userService.isAdmin(userDetails.getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        var userToSuspend = userRepository.findById(userId);
-
-        if (userToSuspend.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-
-        User user = userToSuspend.get();
-
-        if ("admin".equals(user.getRole())) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Cannot suspend another admin.");
-        }
-
-        user.setRole("suspended");
-
-        return ResponseEntity.status(HttpStatus.OK).body(userRepository.save(user));
+        return ResponseEntity.status(HttpStatus.OK).body(userService.suspendUser(userId));
     }
 
     @PutMapping("/{userId}/unsuspend")
     public ResponseEntity<User> unsuspendUser(
             @PathVariable String userId,
             @AuthenticationPrincipal UserDetails userDetails) {
-        User requester = getCurrentUser(userDetails);
-
-        if (!isAdmin(requester)) {
+        if (!userService.isAdmin(userDetails.getUsername())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        var userToUnsuspend = userRepository.findById(userId);
-
-        if (userToUnsuspend.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-
-        User user = userToUnsuspend.get();
-        user.setRole("user");
-
-        return ResponseEntity.status(HttpStatus.OK).body(userRepository.save(user));
-    }
-
-    private User getCurrentUser(UserDetails userDetails) {
-        return userRepository.findByEmail(userDetails.getUsername())
-            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-    }
-
-    private boolean isAdmin(User user) {
-        return "admin".equals(user.getRole());
+        return ResponseEntity.status(HttpStatus.OK).body(userService.unsuspendUser(userId));
     }
 }

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/controller/UserController.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/controller/UserController.java
@@ -82,7 +82,7 @@ public class UserController {
     }
 
     @PutMapping("/{userId}/suspend")
-    public ResponseEntity<User> suspendUser(
+    public ResponseEntity<?> suspendUser(
             @PathVariable String userId,
             @AuthenticationPrincipal UserDetails userDetails) {
         User requester = getCurrentUser(userDetails);
@@ -98,6 +98,11 @@ public class UserController {
         }
 
         User user = userToSuspend.get();
+
+        if ("admin".equals(user.getRole())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Cannot suspend another admin.");
+        }
+
         user.setRole("suspended");
 
         return ResponseEntity.status(HttpStatus.OK).body(userRepository.save(user));

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/dto/UserProfile.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/dto/UserProfile.java
@@ -21,5 +21,7 @@ public class UserProfile {
 
     private boolean isVerified;
 
+    private String role;
+
     private List<ServiceDto> services;
 }

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
@@ -2,6 +2,7 @@ package com.ServiceMarketplace.service_marketplace.service;
 
 import java.util.List;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
@@ -18,6 +19,7 @@ import com.ServiceMarketplace.service_marketplace.dto.ServiceDto;
 import com.ServiceMarketplace.service_marketplace.dto.UpdateUserProfileRequest;
 import com.ServiceMarketplace.service_marketplace.dto.UserProfile;
 import com.ServiceMarketplace.service_marketplace.exception.EmailAlreadyExistsException;
+import com.ServiceMarketplace.service_marketplace.exception.ResourceNotFoundException;
 import com.ServiceMarketplace.service_marketplace.model.User;
 import com.ServiceMarketplace.service_marketplace.repository.UserRepository;
 
@@ -89,7 +91,7 @@ public class UserService {
             throw new BadCredentialsException("Invalid email or password.");
         }
 
-        var user = userRepository.findByEmail(request.getEmail()).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        User user = getUserByEmail(request.getEmail());
 
         String jwtToken = jwtService.generateToken(request.getEmail());
 
@@ -99,8 +101,7 @@ public class UserService {
 
     public UserProfile getUserProfile(UserDetails userDetails){
 
-        var user = userRepository.findByEmail(userDetails.getUsername())
-            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        User user = getUserByEmail(userDetails.getUsername());
 
         return toUserProfile(user);
         
@@ -108,8 +109,7 @@ public class UserService {
 
     public UserProfile updateUserProfile(UserDetails userDetails, UpdateUserProfileRequest request){
 
-        var user = userRepository.findByEmail(userDetails.getUsername())
-            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        User user = getUserByEmail(userDetails.getUsername());
 
         if (request.getBio() != null) {
             user.setBio(clean(request.getBio()));
@@ -119,6 +119,43 @@ public class UserService {
 
         return toUserProfile(saved);
         
+    }
+
+    public User getUserById(String userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+    }
+
+    public User getUserByEmail(String email) {
+        return userRepository.findByEmail(email)
+            .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+    public boolean isAdmin(String email) {
+        return "admin".equals(getUserByEmail(email).getRole());
+    }
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+    public User suspendUser(String userId) {
+        User user = getUserById(userId);
+
+        if ("admin".equals(user.getRole())) {
+            throw new AccessDeniedException("Cannot suspend another admin.");
+        }
+
+        user.setRole("suspended");
+
+        return userRepository.save(user);
+    }
+
+    public User unsuspendUser(String userId) {
+        User user = getUserById(userId);
+        user.setRole("user");
+
+        return userRepository.save(user);
     }
 
     private UserProfile toUserProfile(User user) {

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
@@ -123,7 +123,8 @@ public class UserService {
 
     private UserProfile toUserProfile(User user) {
         return new UserProfile(user.getEmail(), user.getFirstName(), user.getLastName(), user.getMajor(),
-            user.getCampus(), clean(user.getBio()), user.getVerificationStatus(),getProfileServices(user.getId()));
+            user.getCampus(), clean(user.getBio()), user.getVerificationStatus(), user.getRole(),
+            getProfileServices(user.getId()));
     }
 
     private List<ServiceDto> getProfileServices(String userId) {

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
@@ -153,9 +153,17 @@ public class UserService {
 
     public User unsuspendUser(String userId) {
         User user = getUserById(userId);
-        user.setRole("user");
 
-        return userRepository.save(user);
+        if ("admin".equals(user.getRole())) {
+            throw new AccessDeniedException("Cannot unsuspend another admin.");
+        }
+
+        if ("suspended".equals(user.getRole())) {
+            user.setRole("user");
+            return userRepository.save(user);
+        }
+
+        return user;
     }
 
     private UserProfile toUserProfile(User user) {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Navigate, Routes, Route, useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { BrowserRouter, Navigate, Routes, Route, useLocation, useNavigate } from "react-router-dom";
 import Layout from "./components/Layout";
 import HomePage from "./pages/HomePage";
 import SignupPage from "./pages/SignupPage";
@@ -12,14 +13,57 @@ import LandingPage from "./pages/LandingPage";
 import ServiceDashboard from "./pages/ServiceDashboard";
 import AdminDashboard from "./pages/AdminDashboard";
 import SuspendedPage from "./pages/SuspendedPage";
+import { API_ENDPOINTS } from "./utils/api";
+
+const TOKEN_STORAGE_KEY = "jwt_token";
 
 function AppRoutes() {
   const location = useLocation();
+  const navigate = useNavigate();
   const isSuspended = localStorage.getItem("user_role") === "suspended";
   const canAccessWhileSuspended =
     location.pathname === "/login" ||
     location.pathname === "/signup" ||
     location.pathname === "/suspended";
+
+  useEffect(() => {
+    const token = localStorage.getItem(TOKEN_STORAGE_KEY);
+
+    if (!token) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function checkSuspension() {
+      try {
+        const response = await fetch(API_ENDPOINTS.user.profile, {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const user = await response.json();
+
+        if (!cancelled && user.role === "suspended") {
+          localStorage.clear();
+          navigate("/suspended", { replace: true });
+        }
+      } catch {
+        // Keep routing unchanged when the profile check cannot complete.
+      }
+    }
+
+    void checkSuspension();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [location.pathname, location.search, navigate]);
 
   if (isSuspended && !canAccessWhileSuspended) {
     return <Navigate to="/suspended" replace />;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { BrowserRouter, Navigate, Routes, Route, useLocation, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { BrowserRouter, Navigate, Routes, Route, useLocation } from "react-router-dom";
 import Layout from "./components/Layout";
 import HomePage from "./pages/HomePage";
 import SignupPage from "./pages/SignupPage";
@@ -19,7 +19,7 @@ const TOKEN_STORAGE_KEY = "jwt_token";
 
 function AppRoutes() {
   const location = useLocation();
-  const navigate = useNavigate();
+  const [serverSuspended, setServerSuspended] = useState(false);
   const isSuspended = localStorage.getItem("user_role") === "suspended";
   const canAccessWhileSuspended =
     location.pathname === "/login" ||
@@ -47,11 +47,11 @@ function AppRoutes() {
           return;
         }
 
-        const user = await response.json();
+        const user = await response.json() as { role?: string };
 
         if (!cancelled && user.role === "suspended") {
           localStorage.clear();
-          navigate("/suspended", { replace: true });
+          setServerSuspended(true);
         }
       } catch {
         // Keep routing unchanged when the profile check cannot complete.
@@ -63,7 +63,11 @@ function AppRoutes() {
     return () => {
       cancelled = true;
     };
-  }, [location.pathname, location.search, navigate]);
+  }, []);
+
+  if (serverSuspended) {
+    return <Navigate to="/suspended" replace />;
+  }
 
   if (isSuspended && !canAccessWhileSuspended) {
     return <Navigate to="/suspended" replace />;

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -59,9 +59,11 @@ function AppRoutes() {
     }
 
     void checkSuspension();
+    const interval = setInterval(() => void checkSuspension(), 300000);
 
     return () => {
       cancelled = true;
+      clearInterval(interval);
     };
   }, []);
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -44,17 +44,22 @@ function AppRoutes() {
 
     async function checkSuspension() {
       try {
-        const response = await fetch(API_ENDPOINTS.user.profile, {
-          headers: {
-            Authorization: `Bearer ${token}`
+        const response = await fetch(
+          API_ENDPOINTS.user.profile,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`
+            }
           }
-        });
+        );
 
         if (!response.ok) {
           return;
         }
 
-        const user = await response.json() as { role?: string };
+        const user = (await response.json()) as {
+          role?: string;
+        };
 
         if (!cancelled && user.role === "suspended") {
           localStorage.clear();
@@ -66,7 +71,10 @@ function AppRoutes() {
     }
 
     void checkSuspension();
-    const interval = setInterval(() => void checkSuspension(), 300000);
+    const interval = setInterval(
+      () => void checkSuspension(),
+      300000
+    );
 
     return () => {
       cancelled = true;

--- a/packages/frontend/src/components/ServiceDetailsModal.tsx
+++ b/packages/frontend/src/components/ServiceDetailsModal.tsx
@@ -61,6 +61,7 @@ function ServiceDetailsModal({
   const currentUserId = localStorage.getItem("user_id");
   const [showReportDialog, setShowReportDialog] = useState(false);
   const [reportReason, setReportReason] = useState("Inappropriate content");
+  const [otherReportReason, setOtherReportReason] = useState("");
   const [isReporting, setIsReporting] = useState(false);
   const [setupClientSecret, setSetupClientSecret] = useState("");
   const [form, setForm] = useState<BookingFormState>({
@@ -121,6 +122,15 @@ function ServiceDetailsModal({
   }
 
   async function handleReportSubmit() {
+    const trimmedOtherReason = otherReportReason.trim();
+    const submittedReason =
+      reportReason === "Other" ? `Other: ${trimmedOtherReason}` : reportReason;
+
+    if (reportReason === "Other" && !trimmedOtherReason) {
+      toast.error("Please add details for Other.");
+      return;
+    }
+
     setIsReporting(true);
     try {
       const token = localStorage.getItem("jwt_token");
@@ -133,13 +143,15 @@ function ServiceDetailsModal({
         body: JSON.stringify({
           listingId: service.id,
           providerId: service.userId,
-          reason: reportReason
+          reason: submittedReason
         })
       });
 
       if (response.ok) {
         toast.success("Report submitted successfully");
         setShowReportDialog(false);
+        setReportReason("Inappropriate content");
+        setOtherReportReason("");
       } else {
         toast.error("Failed to submit report");
       }
@@ -243,6 +255,14 @@ function ServiceDetailsModal({
                       <option>Harassment</option>
                       <option>Other</option>
                     </select>
+                    {reportReason === "Other" && (
+                      <input
+                        type="text"
+                        value={otherReportReason}
+                        onChange={e => setOtherReportReason(e.target.value)}
+                        placeholder="Add details"
+                      />
+                    )}
                     <div className="report-dialog-actions">
                       <button
                         type="button"

--- a/packages/frontend/src/components/ServiceDetailsModal.tsx
+++ b/packages/frontend/src/components/ServiceDetailsModal.tsx
@@ -64,9 +64,13 @@ function ServiceDetailsModal({
 }: ServiceDetailsModalProps) {
   const [view, setView] = useState<ModalView>("details");
   const currentUserId = localStorage.getItem("user_id");
-  const [showReportDialog, setShowReportDialog] = useState(false);
-  const [reportReason, setReportReason] = useState("Inappropriate content");
-  const [otherReportReason, setOtherReportReason] = useState("");
+  const [showReportDialog, setShowReportDialog] =
+    useState(false);
+  const [reportReason, setReportReason] = useState(
+    "Inappropriate content"
+  );
+  const [otherReportReason, setOtherReportReason] =
+    useState("");
   const [isReporting, setIsReporting] = useState(false);
   const [setupClientSecret, setSetupClientSecret] =
     useState("");
@@ -145,7 +149,9 @@ function ServiceDetailsModal({
   async function handleReportSubmit() {
     const trimmedOtherReason = otherReportReason.trim();
     const submittedReason =
-      reportReason === "Other" ? `Other: ${trimmedOtherReason}` : reportReason;
+      reportReason === "Other"
+        ? `Other: ${trimmedOtherReason}`
+        : reportReason;
 
     if (reportReason === "Other" && !trimmedOtherReason) {
       toast.error("Please add details for Other.");
@@ -288,7 +294,9 @@ function ServiceDetailsModal({
                       <textarea
                         className="report-other-input"
                         value={otherReportReason}
-                        onChange={e => setOtherReportReason(e.target.value)}
+                        onChange={(e) =>
+                          setOtherReportReason(e.target.value)
+                        }
                         rows={3}
                         maxLength={250}
                         placeholder="Add details"

--- a/packages/frontend/src/components/ServiceDetailsModal.tsx
+++ b/packages/frontend/src/components/ServiceDetailsModal.tsx
@@ -256,11 +256,12 @@ function ServiceDetailsModal({
                       <option>Other</option>
                     </select>
                     {reportReason === "Other" && (
-                      <input
-                        type="text"
+                      <textarea
+                        className="report-other-input"
                         value={otherReportReason}
                         onChange={e => setOtherReportReason(e.target.value)}
-                        maxLength={500}
+                        rows={3}
+                        maxLength={250}
                         placeholder="Add details"
                       />
                     )}

--- a/packages/frontend/src/components/ServiceDetailsModal.tsx
+++ b/packages/frontend/src/components/ServiceDetailsModal.tsx
@@ -260,6 +260,7 @@ function ServiceDetailsModal({
                         type="text"
                         value={otherReportReason}
                         onChange={e => setOtherReportReason(e.target.value)}
+                        maxLength={500}
                         placeholder="Add details"
                       />
                     )}

--- a/packages/frontend/src/components/styles/AdminDashboard.css
+++ b/packages/frontend/src/components/styles/AdminDashboard.css
@@ -27,6 +27,24 @@
   font-weight: 700;
 }
 
+.admin-dashboard-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.admin-dashboard-toggle {
+  border: 1px solid #cfd6df;
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: #ffffff;
+  color: #071b2d;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
 .admin-dashboard-table-wrap {
   overflow-x: auto;
   border: 1px solid #cfd6df;
@@ -142,6 +160,11 @@
   }
 
   .admin-dashboard-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .admin-dashboard-header-actions {
     align-items: flex-start;
     flex-direction: column;
   }

--- a/packages/frontend/src/components/styles/AdminDashboard.css
+++ b/packages/frontend/src/components/styles/AdminDashboard.css
@@ -1,6 +1,10 @@
 .admin-dashboard {
-  width: min(1180px, calc(100% - 32px));
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
   margin: 32px auto;
+  overflow-x: hidden;
+  padding: 0 16px;
   color: #071b2d;
 }
 
@@ -47,6 +51,8 @@
 
 .admin-dashboard-table-wrap {
   overflow-x: auto;
+  max-width: 100%;
+  width: 100%;
   border: 1px solid #cfd6df;
   border-radius: 8px;
   background: #ffffff;
@@ -54,8 +60,8 @@
 
 .admin-dashboard-table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
-  min-width: 980px;
 }
 
 .admin-dashboard-table th,
@@ -75,8 +81,11 @@
 }
 
 .admin-dashboard-table td {
+  max-width: 200px;
   color: #25364a;
   font-size: 14px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .admin-dashboard-table tbody tr:last-child td {
@@ -111,7 +120,7 @@
 }
 
 .admin-dashboard-users-table {
-  min-width: 620px;
+  min-width: 0;
 }
 
 .admin-dashboard-empty {
@@ -144,6 +153,10 @@
   background: #c06b16;
 }
 
+.admin-dashboard-action-neutral {
+  background: #5f6f82;
+}
+
 .admin-dashboard-action-success {
   background: #1f7a4d;
 }
@@ -155,8 +168,8 @@
 
 @media (max-width: 720px) {
   .admin-dashboard {
-    width: min(100% - 24px, 1180px);
     margin: 20px auto;
+    padding: 0 12px;
   }
 
   .admin-dashboard-header {

--- a/packages/frontend/src/components/styles/Layout.css
+++ b/packages/frontend/src/components/styles/Layout.css
@@ -8,11 +8,14 @@
 .content-area {
   display: flex;
   flex-direction: column; /* NavBar top, Main content bottom */
-  flex-grow: 1;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .main-content {
-  flex-grow: 1;
+  flex: 1 1 auto;
+  min-width: 0;
   background-color: #ffffff;
+  overflow-x: hidden;
   overflow-y: auto;
 }

--- a/packages/frontend/src/components/styles/ServiceDetailsModal.css
+++ b/packages/frontend/src/components/styles/ServiceDetailsModal.css
@@ -335,6 +335,16 @@
   border: 1px solid #ccc;
 }
 
+.report-dialog input {
+  box-sizing: border-box;
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font: inherit;
+}
+
 .report-dialog-actions {
   display: flex;
   gap: 8px;

--- a/packages/frontend/src/components/styles/ServiceDetailsModal.css
+++ b/packages/frontend/src/components/styles/ServiceDetailsModal.css
@@ -345,6 +345,19 @@
   font: inherit;
 }
 
+.report-other-input {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  resize: vertical;
+  word-break: break-word;
+  padding: 8px;
+  margin-bottom: 12px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font: inherit;
+}
+
 .report-dialog-actions {
   display: flex;
   gap: 8px;

--- a/packages/frontend/src/components/styles/SideBar.css
+++ b/packages/frontend/src/components/styles/SideBar.css
@@ -1,5 +1,7 @@
 .sidebar-container {
+  flex: 0 0 220px;
   width: 220px;
+  min-width: 220px;
   border-right: 1px solid #eee;
   display: flex;
   flex-direction: column;

--- a/packages/frontend/src/pages/AdminDashboard.tsx
+++ b/packages/frontend/src/pages/AdminDashboard.tsx
@@ -222,14 +222,30 @@ function AdminDashboard() {
       });
 
       if (!response.ok) {
-        throw new Error("Failed to suspend user");
+        if (response.status === 403) {
+          const responseText = await response.text();
+          toast.error(
+            responseText.includes("Cannot suspend another admin")
+              ? "Cannot suspend another admin."
+              : "You do not have permission to perform this action."
+          );
+          return;
+        }
+
+        if (response.status === 404) {
+          toast.error("User not found.");
+          return;
+        }
+
+        toast.error("Failed to suspend user. Please try again.");
+        return;
       }
 
       await resolveReport(report.id);
       toast.success("User suspended");
       setReloadVersion((version) => version + 1);
     } catch {
-      toast.error("Failed to suspend user");
+      toast.error("Failed to suspend user. Please try again.");
     } finally {
       setActiveReportAction(null);
     }

--- a/packages/frontend/src/pages/AdminDashboard.tsx
+++ b/packages/frontend/src/pages/AdminDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
 import { toast } from "react-toastify";
 import { API_ENDPOINTS } from "../utils/api";
 import "../components/styles/AdminDashboard.css";
@@ -53,11 +54,13 @@ function getAuthHeaders() {
 }
 
 function AdminDashboard() {
+  const authToken = localStorage.getItem(TOKEN_STORAGE_KEY);
   const [reports, setReports] = useState<Report[]>([]);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [reportUsers, setReportUsers] = useState<Record<string, AdminUser>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [accessDenied, setAccessDenied] = useState(false);
+  const [showResolved, setShowResolved] = useState(false);
   const [activeReportAction, setActiveReportAction] = useState<{
     reportId: string;
     action: ReportAction;
@@ -66,8 +69,15 @@ function AdminDashboard() {
   const [reloadVersion, setReloadVersion] = useState(0);
   const currentUserId = localStorage.getItem("user_id");
   const suspendedUsers = users.filter((user) => user.role === "suspended");
+  const visibleReports = showResolved
+    ? reports
+    : reports.filter((report) => report.status !== "resolved");
 
   useEffect(() => {
+    if (authToken === null) {
+      return;
+    }
+
     let cancelled = false;
 
     async function load() {
@@ -166,7 +176,7 @@ function AdminDashboard() {
     return () => {
       cancelled = true;
     };
-  }, [reloadVersion]);
+  }, [authToken, reloadVersion]);
 
   async function resolveReport(reportId: string) {
     const response = await fetch(API_ENDPOINTS.reports.resolve(reportId), {
@@ -257,6 +267,10 @@ function AdminDashboard() {
     return getUserName(user);
   }
 
+  if (authToken === null) {
+    return <Navigate to="/login" replace />;
+  }
+
   if (accessDenied) {
     return (
       <main className="admin-dashboard">
@@ -269,7 +283,17 @@ function AdminDashboard() {
     <main className="admin-dashboard">
       <div className="admin-dashboard-header">
         <h1>Admin Dashboard</h1>
-        <p>{reports.length} reports</p>
+        <div className="admin-dashboard-header-actions">
+          <p>
+            {visibleReports.length} {showResolved ? "reports" : "open reports"}
+          </p>
+          <button
+            type="button"
+            className="admin-dashboard-toggle"
+            onClick={() => setShowResolved((value) => !value)}>
+            {showResolved ? "Hide Resolved" : "Show Resolved"}
+          </button>
+        </div>
       </div>
 
       {isLoading ? (
@@ -290,14 +314,14 @@ function AdminDashboard() {
                 </tr>
               </thead>
               <tbody>
-                {reports.length === 0 ? (
+                {visibleReports.length === 0 ? (
                   <tr>
                     <td colSpan={7} className="admin-dashboard-empty">
-                      No reports found.
+                      {showResolved ? "No reports found." : "No open reports found."}
                     </td>
                   </tr>
                 ) : (
-                  reports.map((report) => {
+                  visibleReports.map((report) => {
                     const isSelfSuspension = report.providerId === currentUserId;
 
                     return (
@@ -323,11 +347,7 @@ function AdminDashboard() {
                             <button
                               type="button"
                               className="admin-dashboard-action admin-dashboard-action-warning"
-                              disabled={
-                                isSelfSuspension ||
-                                (activeReportAction?.reportId === report.id &&
-                                  activeReportAction.action === "suspend")
-                              }
+                              disabled={isSelfSuspension}
                               onClick={() => void suspendUser(report)}>
                               Suspend User
                             </button>

--- a/packages/frontend/src/pages/AdminDashboard.tsx
+++ b/packages/frontend/src/pages/AdminDashboard.tsx
@@ -363,7 +363,11 @@ function AdminDashboard() {
                             <button
                               type="button"
                               className="admin-dashboard-action admin-dashboard-action-warning"
-                              disabled={isSelfSuspension}
+                              disabled={
+                                isSelfSuspension ||
+                                (activeReportAction?.reportId === report.id &&
+                                  activeReportAction.action === "suspend")
+                              }
                               onClick={() => void suspendUser(report)}>
                               Suspend User
                             </button>

--- a/packages/frontend/src/pages/AdminDashboard.tsx
+++ b/packages/frontend/src/pages/AdminDashboard.tsx
@@ -24,7 +24,7 @@ interface AdminUser {
   role: string;
 }
 
-type ReportAction = "remove" | "suspend";
+type ReportAction = "remove" | "suspend" | "resolve";
 
 function formatDate(value?: string) {
   if (!value) {
@@ -247,6 +247,21 @@ function AdminDashboard() {
     } catch {
       toast.error("Failed to suspend user. Please try again.");
     } finally {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      setActiveReportAction(null);
+    }
+  }
+
+  async function resolveOnly(report: Report) {
+    setActiveReportAction({ reportId: report.id, action: "resolve" });
+
+    try {
+      await resolveReport(report.id);
+      toast.success("Report resolved");
+      setReloadVersion((version) => version + 1);
+    } catch {
+      toast.error("Failed to resolve report");
+    } finally {
       setActiveReportAction(null);
     }
   }
@@ -370,6 +385,13 @@ function AdminDashboard() {
                               }
                               onClick={() => void suspendUser(report)}>
                               Suspend User
+                            </button>
+                            <button
+                              type="button"
+                              className="admin-dashboard-action admin-dashboard-action-neutral"
+                              disabled={activeReportAction?.reportId === report.id}
+                              onClick={() => void resolveOnly(report)}>
+                              Resolve Only
                             </button>
                           </div>
                         </td>

--- a/packages/frontend/src/pages/AdminDashboard.tsx
+++ b/packages/frontend/src/pages/AdminDashboard.tsx
@@ -264,7 +264,9 @@ function AdminDashboard() {
         if (response.status === 403) {
           const responseText = await response.text();
           toast.error(
-            responseText.includes("Cannot suspend another admin")
+            responseText.includes(
+              "Cannot suspend another admin"
+            )
               ? "Cannot suspend another admin."
               : "You do not have permission to perform this action."
           );
@@ -276,7 +278,9 @@ function AdminDashboard() {
           return;
         }
 
-        toast.error("Failed to suspend user. Please try again.");
+        toast.error(
+          "Failed to suspend user. Please try again."
+        );
         return;
       }
 
@@ -292,7 +296,10 @@ function AdminDashboard() {
   }
 
   async function resolveOnly(report: Report) {
-    setActiveReportAction({ reportId: report.id, action: "resolve" });
+    setActiveReportAction({
+      reportId: report.id,
+      action: "resolve"
+    });
 
     try {
       await resolveReport(report.id);
@@ -360,7 +367,8 @@ function AdminDashboard() {
         <h1>Admin Dashboard</h1>
         <div className="admin-dashboard-header-actions">
           <p>
-            {visibleReports.length} {showResolved ? "reports" : "open reports"}
+            {visibleReports.length}{" "}
+            {showResolved ? "reports" : "open reports"}
           </p>
           <button
             type="button"
@@ -396,7 +404,9 @@ function AdminDashboard() {
                     <td
                       colSpan={7}
                       className="admin-dashboard-empty">
-                      {showResolved ? "No reports found." : "No open reports found."}
+                      {showResolved
+                        ? "No reports found."
+                        : "No open reports found."}
                     </td>
                   </tr>
                 ) : (
@@ -450,8 +460,13 @@ function AdminDashboard() {
                             <button
                               type="button"
                               className="admin-dashboard-action admin-dashboard-action-neutral"
-                              disabled={activeReportAction?.reportId === report.id}
-                              onClick={() => void resolveOnly(report)}>
+                              disabled={
+                                activeReportAction?.reportId ===
+                                report.id
+                              }
+                              onClick={() =>
+                                void resolveOnly(report)
+                              }>
                               Resolve Only
                             </button>
                           </div>


### PR DESCRIPTION
Fixed suspension not being detected on app load — added role field to UserProfile DTO so /api/users/me returns the user's role, allowing App.tsx to redirect suspended users on route change
Fixed Suspend button disabled for all admins instead of just self — now only disabled for current user
Added open/resolved report filter toggle to admin dashboard — defaults to open reports only
Added "Other" text input in report dialog for additional details
Blocked admin-to-admin suspension on backend with 403
Fixed /admin redirecting to login when no JWT present

none of these are tested with anyone else besides myself