### PR TITLE
feat(booking): ST-16 send confirmation emails at booking and payment

### DIFF
--- a/packages/backend/service-marketplace/pom.xml
+++ b/packages/backend/service-marketplace/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>com.stripe</groupId>
             <artifactId>stripe-java</artifactId>
-            <version>28.3.0</version>
+            <version>29.2.0</version>
         </dependency>
 
     </dependencies>

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/exception/GlobalExceptionHandler.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.ServiceMarketplace.service_marketplace.exception;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -15,6 +17,8 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
     
     @ExceptionHandler(EmailAlreadyExistsException.class)
     public ResponseEntity<String> handleEmailAlreadyExists(EmailAlreadyExistsException e) {
@@ -65,6 +69,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(EmailSendException.class)
     public ResponseEntity<String> handleEmailSendException(EmailSendException e) {
+        log.error("EmailSendException: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
@@ -95,6 +100,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(PaymentProcessingException.class)
     public ResponseEntity<String> handlePaymentProcessingException(PaymentProcessingException e) {
+        log.error("PaymentProcessingException: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 
@@ -105,6 +111,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(WebhookProcessingException.class)
     public ResponseEntity<String> handleWebhookProcessing(WebhookProcessingException e) {
+        log.error("WebhookProcessingException: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
     }
 

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/BookingService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/BookingService.java
@@ -82,6 +82,16 @@ public class BookingService {
 
         Booking saved = bookingRepository.save(booking);
 
+        emailService.sendBookingRequestedCustomerEmail(
+            customer.getEmail(),
+            customer.getFirstName(),
+            service.getTitle(),
+            request.getProposedPrice(),
+            service.getPriceUnit(),
+            request.getScheduledAt(),
+            saved.getId()
+        );
+
         TokenPair tokenPair = bookingTokenService.generateTokenPair(saved.getId());
 
         emailService.sendProviderBookingNotificationEmail(

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/EmailService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/EmailService.java
@@ -56,6 +56,19 @@ public class EmailService {
             ));
     }
 
+    public void sendBookingRequestedCustomerEmail(String toEmail, String customerName, String serviceTitle,
+            BigDecimal proposedPrice, String priceUnit, Instant scheduledAt, String bookingId) {
+        sendTemplatedEmail(toEmail, "Booking Request Received - " + serviceTitle, "bookingRequestedCustomer",
+            Map.of(
+                "customerName", customerName,
+                "serviceTitle", serviceTitle,
+                "proposedPrice", formatPrice(proposedPrice),
+                "priceUnit", priceUnit != null ? priceUnit : "",
+                "scheduledAt", DATE_FORMATTER.format(scheduledAt),
+                "bookingId", bookingId
+            ));
+    }
+
     public void sendBookingConfirmedCustomerEmail(String toEmail, String customerName, String serviceTitle,
             BigDecimal agreedPrice, String priceUnit, Instant scheduledAt, String bookingId) {
         sendTemplatedEmail(toEmail, "Booking Confirmed - " + serviceTitle, "bookingConfirmedCustomer",

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/PaymentService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/PaymentService.java
@@ -219,9 +219,12 @@ public class PaymentService {
             throw new InvalidWebhookSignatureException("Invalid webhook signature: " + e.getMessage());
         }
 
-        StripeObject stripeObject = event.getDataObjectDeserializer()
-            .getObject()
-            .orElseThrow(() -> new WebhookProcessingException("Failed to deserialize webhook event"));
+        StripeObject stripeObject;
+        try {
+            stripeObject = event.getDataObjectDeserializer().deserializeUnsafe();
+        } catch (Exception e) {
+            throw new WebhookProcessingException("Failed to deserialize webhook event");
+        }
 
         switch (event.getType()) {
             case "payment_intent.succeeded" -> {

--- a/packages/backend/service-marketplace/src/main/resources/templates/bookingRequestedCustomer.html
+++ b/packages/backend/service-marketplace/src/main/resources/templates/bookingRequestedCustomer.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Booking Request Received</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: Arial, sans-serif;">
+
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td align="center" style="padding: 40px 20px;">
+
+        <table width="100%" cellpadding="0" cellspacing="0" border="0"
+               style="max-width: 500px; background-color: #ffffff; border-radius: 8px; padding: 40px;">
+
+          <tr>
+            <td align="center">
+              <h1 style="margin: 0; color: #333333;">Booking Request Received</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 20px; color: #555555; font-size: 16px; line-height: 24px;">
+              Hi <strong>[[${customerName}]]</strong>,
+              <br /><br />
+              Your booking request has been submitted. The provider will review your request and confirm the price shortly. You will receive another email once your booking is confirmed and your payment is processed.
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 24px;">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0"
+                     style="background-color: #f8f8f8; border-radius: 6px; padding: 20px;">
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Service:</strong> [[${serviceTitle}]]
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Proposed Price:</strong> [[${proposedPrice}]] <span style="color: #888888;">[[${priceUnit}]]</span>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Scheduled:</strong> [[${scheduledAt}]]
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #888888; font-size: 13px;">
+                    Booking ID: [[${bookingId}]]
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 20px; color: #777777; font-size: 14px; line-height: 22px;">
+              Your card will not be charged until the provider confirms the booking.
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding-top: 30px; font-size: 12px; color: #999999;">
+              &copy; 2026 Service Market Place. All rights reserved.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/BookingServiceTest.java
+++ b/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/BookingServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -113,6 +114,11 @@ class BookingServiceTest {
         assertThat(result.getBooking().getStatus()).isEqualTo(BookingStatus.AWAITING_PROVIDER_CONFIRMATION);
         assertThat(result.getSetupClientSecret()).isEqualTo("seti_secret_test");
 
+        verify(emailService).sendBookingRequestedCustomerEmail(
+            eq("student@calpoly.edu"), eq("Alice"), eq("Math Tutoring"),
+            eq(new BigDecimal("50.00")), eq("per hour"), any(Instant.class),
+            Mockito.isNull()
+        );
         verify(bookingTokenService).generateTokenPair(any());
         verify(emailService).sendProviderBookingNotificationEmail(
             eq("tutor@calpoly.edu"), eq("Bob"), eq("Alice Student"), eq("Math Tutoring"),

--- a/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/PaymentServiceTest.java
+++ b/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/PaymentServiceTest.java
@@ -1,0 +1,172 @@
+package com.ServiceMarketplace.service_marketplace;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ServiceMarketplace.service_marketplace.exception.InvalidWebhookSignatureException;
+import com.ServiceMarketplace.service_marketplace.model.Booking;
+import com.ServiceMarketplace.service_marketplace.model.BookingStatus;
+import com.ServiceMarketplace.service_marketplace.model.User;
+import com.ServiceMarketplace.service_marketplace.repository.BookingRepository;
+import com.ServiceMarketplace.service_marketplace.repository.UserRepository;
+import com.ServiceMarketplace.service_marketplace.service.EmailService;
+import com.ServiceMarketplace.service_marketplace.service.PaymentService;
+import com.stripe.model.Customer;
+import com.stripe.model.Event;
+import com.stripe.model.EventDataObjectDeserializer;
+import com.stripe.model.PaymentIntent;
+import com.stripe.model.StripeObject;
+import com.stripe.net.Webhook;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock private BookingRepository bookingRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private EmailService emailService;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private Booking mockBooking;
+    private User mockCustomer;
+    private User mockProvider;
+
+    @BeforeEach
+    void setUp() {
+        mockBooking = new Booking();
+        mockBooking.setId("booking-001");
+        mockBooking.setStripePaymentIntentId("pi_test_123");
+        mockBooking.setStripeCustomerId("cus_test_123");
+        mockBooking.setCustomerId("customer-789");
+        mockBooking.setProviderId("provider-456");
+        mockBooking.setServiceTitle("Math Tutoring");
+        mockBooking.setAgreedPrice(new BigDecimal("50.00"));
+        mockBooking.setPriceUnit("per hour");
+        mockBooking.setScheduledAt(Instant.now());
+        mockBooking.setStatus(BookingStatus.PENDING_PAYMENT);
+
+        mockCustomer = new User();
+        mockCustomer.setId("customer-789");
+        mockCustomer.setEmail("student@calpoly.edu");
+        mockCustomer.setFirstName("Alice");
+
+        mockProvider = new User();
+        mockProvider.setId("provider-456");
+        mockProvider.setEmail("tutor@calpoly.edu");
+        mockProvider.setFirstName("Bob");
+    }
+
+    @Test
+    void handleWebhook_paymentSucceeded_updatesBookingToConfirmedAndSendsEmails() {
+        Event mockEvent = buildMockEvent("payment_intent.succeeded", "pi_test_123");
+        try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class)) {
+            webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
+                .thenReturn(mockEvent);
+
+            when(bookingRepository.findByStripePaymentIntentId("pi_test_123")).thenReturn(Optional.of(mockBooking));
+            when(bookingRepository.save(any(Booking.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(userRepository.findById("customer-789")).thenReturn(Optional.of(mockCustomer));
+            when(userRepository.findById("provider-456")).thenReturn(Optional.of(mockProvider));
+
+            paymentService.handleWebhook("payload", "sig-header");
+
+            assertThat(mockBooking.getStatus()).isEqualTo(BookingStatus.CONFIRMED);
+            verify(bookingRepository).save(mockBooking);
+            verify(emailService).sendBookingConfirmedCustomerEmail(
+                eq("student@calpoly.edu"), eq("Alice"), eq("Math Tutoring"),
+                any(BigDecimal.class), eq("per hour"), any(Instant.class), eq("booking-001")
+            );
+            verify(emailService).sendBookingConfirmedProviderEmail(
+                eq("tutor@calpoly.edu"), eq("Bob"), eq("Math Tutoring"),
+                any(BigDecimal.class), eq("per hour"), any(Instant.class), eq("booking-001")
+            );
+        }
+    }
+
+    @Test
+    void handleWebhook_paymentFailed_updatesBookingToCancelledAndCleansUpStripeCustomer() {
+        Event mockEvent = buildMockEvent("payment_intent.payment_failed", "pi_test_123");
+        try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class);
+             MockedStatic<Customer> customerMock = Mockito.mockStatic(Customer.class)) {
+
+            webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
+                .thenReturn(mockEvent);
+
+            Customer mockStripeCustomer = mock(Customer.class);
+            customerMock.when(() -> Customer.retrieve("cus_test_123")).thenReturn(mockStripeCustomer);
+
+            when(bookingRepository.findByStripePaymentIntentId("pi_test_123")).thenReturn(Optional.of(mockBooking));
+            when(bookingRepository.save(any(Booking.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            paymentService.handleWebhook("payload", "sig-header");
+
+            assertThat(mockBooking.getStatus()).isEqualTo(BookingStatus.CANCELLED);
+            verify(bookingRepository).save(mockBooking);
+            customerMock.verify(() -> Customer.retrieve("cus_test_123"));
+            verify(emailService, never()).sendBookingConfirmedCustomerEmail(any(), any(), any(), any(), any(), any(), any());
+        }
+    }
+
+    @Test
+    void handleWebhook_invalidSignature_throwsInvalidWebhookSignatureException() {
+        try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class)) {
+            webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
+                .thenThrow(new RuntimeException("Invalid signature"));
+
+            assertThatThrownBy(() -> paymentService.handleWebhook("payload", "bad-sig"))
+                .isInstanceOf(InvalidWebhookSignatureException.class);
+        }
+    }
+
+    @Test
+    void handleWebhook_unknownEventType_noBookingUpdate() {
+        Event mockEvent = buildMockEvent("customer.created", null);
+        try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class)) {
+            webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
+                .thenReturn(mockEvent);
+
+            paymentService.handleWebhook("payload", "sig-header");
+
+            verify(bookingRepository, never()).findByStripePaymentIntentId(any());
+            verify(bookingRepository, never()).save(any());
+        }
+    }
+
+    private Event buildMockEvent(String eventType, String paymentIntentId) {
+        Event event = mock(Event.class);
+        when(event.getType()).thenReturn(eventType);
+
+        EventDataObjectDeserializer deserializer = mock(EventDataObjectDeserializer.class);
+
+        if (paymentIntentId != null) {
+            PaymentIntent paymentIntent = mock(PaymentIntent.class);
+            when(paymentIntent.getId()).thenReturn(paymentIntentId);
+            when(deserializer.getObject()).thenReturn(Optional.of(paymentIntent));
+        } else {
+            StripeObject stripeObject = mock(StripeObject.class);
+            when(deserializer.getObject()).thenReturn(Optional.of(stripeObject));
+        }
+
+        when(event.getDataObjectDeserializer()).thenReturn(deserializer);
+        return event;
+    }
+}

--- a/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/PaymentServiceTest.java
+++ b/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/PaymentServiceTest.java
@@ -76,7 +76,7 @@ class PaymentServiceTest {
     }
 
     @Test
-    void handleWebhook_paymentSucceeded_updatesBookingToConfirmedAndSendsEmails() {
+    void handleWebhook_paymentSucceeded_updatesBookingToConfirmedAndSendsEmails() throws Exception {
         Event mockEvent = buildMockEvent("payment_intent.succeeded", "pi_test_123");
         try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class)) {
             webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
@@ -103,7 +103,7 @@ class PaymentServiceTest {
     }
 
     @Test
-    void handleWebhook_paymentFailed_updatesBookingToCancelledAndCleansUpStripeCustomer() {
+    void handleWebhook_paymentFailed_updatesBookingToCancelledAndCleansUpStripeCustomer() throws Exception {
         Event mockEvent = buildMockEvent("payment_intent.payment_failed", "pi_test_123");
         try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class);
              MockedStatic<Customer> customerMock = Mockito.mockStatic(Customer.class)) {
@@ -138,7 +138,7 @@ class PaymentServiceTest {
     }
 
     @Test
-    void handleWebhook_unknownEventType_noBookingUpdate() {
+    void handleWebhook_unknownEventType_noBookingUpdate() throws Exception {
         Event mockEvent = buildMockEvent("customer.created", null);
         try (MockedStatic<Webhook> webhookMock = Mockito.mockStatic(Webhook.class)) {
             webhookMock.when(() -> Webhook.constructEvent(any(), any(), any()))
@@ -151,7 +151,7 @@ class PaymentServiceTest {
         }
     }
 
-    private Event buildMockEvent(String eventType, String paymentIntentId) {
+    private Event buildMockEvent(String eventType, String paymentIntentId) throws Exception {
         Event event = mock(Event.class);
         when(event.getType()).thenReturn(eventType);
 
@@ -160,10 +160,9 @@ class PaymentServiceTest {
         if (paymentIntentId != null) {
             PaymentIntent paymentIntent = mock(PaymentIntent.class);
             when(paymentIntent.getId()).thenReturn(paymentIntentId);
-            when(deserializer.getObject()).thenReturn(Optional.of(paymentIntent));
+            when(deserializer.deserializeUnsafe()).thenReturn(paymentIntent);
         } else {
-            StripeObject stripeObject = mock(StripeObject.class);
-            when(deserializer.getObject()).thenReturn(Optional.of(stripeObject));
+            when(deserializer.deserializeUnsafe()).thenReturn(mock(StripeObject.class));
         }
 
         when(event.getDataObjectDeserializer()).thenReturn(deserializer);


### PR DESCRIPTION
- Send customer a booking request confirmation email immediately on submission
- Send both customer and provider final confirmation emails when payment succeeds via Stripe webhook
- Fix webhook event deserialization using deserializeUnsafe() for Stripe API version compatibility
- Upgrade stripe-java from 28.3.0 to 29.2.0
- Add error logging to GlobalExceptionHandler for 500-level exceptions
- Add PaymentServiceTest covering webhook confirmation and failure flows