### PR TITLE
feat(bookings): ST-18 notify other party on booking cancellation

### DIFF
--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/exception/GlobalExceptionHandler.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/exception/GlobalExceptionHandler.java
@@ -25,6 +25,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());
     }
 
+    @ExceptionHandler(InvalidEmailDomainException.class)
+    public ResponseEntity<String> handleInvalidEmailDomain(InvalidEmailDomainException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
     @ExceptionHandler(VerificationCodeExpired.class)
     public ResponseEntity<String> handleExpiredVerificationCode(VerificationCodeExpired e){
         return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT).body(e.getMessage());

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/exception/InvalidEmailDomainException.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/exception/InvalidEmailDomainException.java
@@ -1,0 +1,8 @@
+package com.ServiceMarketplace.service_marketplace.exception;
+
+public class InvalidEmailDomainException extends RuntimeException {
+
+    public InvalidEmailDomainException(String message) {
+        super(message);
+    }
+}

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/BookingService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/BookingService.java
@@ -137,7 +137,7 @@ public class BookingService {
             throw new AccessDeniedException("You are not authorized to cancel this booking");
         }
 
-        return doCancelBooking(booking);
+        return doCancelBooking(booking, isCustomer);
     }
 
     public BookingTokenAction processTokenAction(String token) {
@@ -151,7 +151,7 @@ public class BookingService {
                 .orElseThrow(() -> new ResourceNotFoundException("Provider", booking.getProviderId()));
             doConfirmBooking(booking, booking.getAgreedPrice(), provider);
         } else {
-            doCancelBooking(booking);
+            doCancelBooking(booking, false);
         }
 
         return result.action();
@@ -187,14 +187,44 @@ public class BookingService {
         return toBookingResponse(bookingRepository.save(booking));
     }
 
-    private BookingResponse doCancelBooking(Booking booking) {
-        if (booking.getStatus() != BookingStatus.AWAITING_PROVIDER_CONFIRMATION) {
-            throw new BookingStateException("Only bookings awaiting confirmation can be cancelled");
+    private BookingResponse doCancelBooking(Booking booking, boolean cancelledByCustomer) {
+        if (booking.getStatus() == BookingStatus.CANCELLED) {
+            throw new BookingStateException("Booking is already cancelled");
         }
 
         booking.setStatus(BookingStatus.CANCELLED);
         bookingRepository.save(booking);
         paymentService.cleanupStripeCustomer(booking.getStripeCustomerId());
+
+        if (cancelledByCustomer) {
+            userRepository.findById(booking.getProviderId()).ifPresent(provider -> {
+                String customerName = userRepository.findById(booking.getCustomerId())
+                    .map(c -> c.getFirstName() + " " + c.getLastName())
+                    .orElse("A customer");
+                emailService.sendBookingCancelledProviderEmail(
+                    provider.getEmail(),
+                    provider.getFirstName(),
+                    customerName,
+                    booking.getServiceTitle(),
+                    booking.getScheduledAt(),
+                    booking.getId()
+                );
+            });
+        } else {
+            userRepository.findById(booking.getCustomerId()).ifPresent(customer -> {
+                String providerName = userRepository.findById(booking.getProviderId())
+                    .map(p -> p.getFirstName() + " " + p.getLastName())
+                    .orElse("The provider");
+                emailService.sendBookingCancelledCustomerEmail(
+                    customer.getEmail(),
+                    customer.getFirstName(),
+                    providerName,
+                    booking.getServiceTitle(),
+                    booking.getScheduledAt(),
+                    booking.getId()
+                );
+            });
+        }
 
         return toBookingResponse(booking);
     }

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/EmailService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/EmailService.java
@@ -95,6 +95,30 @@ public class EmailService {
             ));
     }
 
+    public void sendBookingCancelledProviderEmail(String toEmail, String providerName, String customerName,
+            String serviceTitle, Instant scheduledAt, String bookingId) {
+        sendTemplatedEmail(toEmail, "Booking Cancelled - " + serviceTitle, "bookingCancelledProvider",
+            Map.of(
+                "providerName", providerName,
+                "customerName", customerName,
+                "serviceTitle", serviceTitle,
+                "scheduledAt", DATE_FORMATTER.format(scheduledAt),
+                "bookingId", bookingId
+            ));
+    }
+
+    public void sendBookingCancelledCustomerEmail(String toEmail, String customerName, String providerName,
+            String serviceTitle, Instant scheduledAt, String bookingId) {
+        sendTemplatedEmail(toEmail, "Booking Cancelled - " + serviceTitle, "bookingCancelledCustomer",
+            Map.of(
+                "customerName", customerName,
+                "providerName", providerName,
+                "serviceTitle", serviceTitle,
+                "scheduledAt", DATE_FORMATTER.format(scheduledAt),
+                "bookingId", bookingId
+            ));
+    }
+
     private void sendTemplatedEmail(String toEmail, String subject, String templateName, Map<String, Object> variables) {
         Context context = new Context();
         variables.forEach(context::setVariable);

--- a/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
+++ b/packages/backend/service-marketplace/src/main/java/com/ServiceMarketplace/service_marketplace/service/UserService.java
@@ -18,6 +18,7 @@ import com.ServiceMarketplace.service_marketplace.dto.ServiceDto;
 import com.ServiceMarketplace.service_marketplace.dto.UpdateUserProfileRequest;
 import com.ServiceMarketplace.service_marketplace.dto.UserProfile;
 import com.ServiceMarketplace.service_marketplace.exception.EmailAlreadyExistsException;
+import com.ServiceMarketplace.service_marketplace.exception.InvalidEmailDomainException;
 import com.ServiceMarketplace.service_marketplace.model.User;
 import com.ServiceMarketplace.service_marketplace.repository.UserRepository;
 
@@ -51,6 +52,10 @@ public class UserService {
     }
 
     public AuthResponse registerUser(RegisterRequest request) {
+        if (!request.getEmail().endsWith("@calpoly.edu")) {
+            throw new InvalidEmailDomainException("Registration is limited to Cal Poly email addresses.");
+        }
+
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new EmailAlreadyExistsException(request.getEmail());
         }

--- a/packages/backend/service-marketplace/src/main/resources/templates/bookingCancelledCustomer.html
+++ b/packages/backend/service-marketplace/src/main/resources/templates/bookingCancelledCustomer.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Booking Cancelled</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: Arial, sans-serif;">
+
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td align="center" style="padding: 40px 20px;">
+
+        <table width="100%" cellpadding="0" cellspacing="0" border="0"
+               style="max-width: 500px; background-color: #ffffff; border-radius: 8px; padding: 40px;">
+
+          <tr>
+            <td align="center">
+              <h1 style="margin: 0; color: #333333;">Booking Cancelled</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 20px; color: #555555; font-size: 16px; line-height: 24px;">
+              Hi <strong>[[${customerName}]]</strong>,
+              <br /><br />
+              <strong>[[${providerName}]]</strong> has cancelled your booking for <strong>[[${serviceTitle}]]</strong>. No payment was collected.
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 24px;">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0"
+                     style="background-color: #f8f8f8; border-radius: 6px; padding: 20px;">
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Service:</strong> [[${serviceTitle}]]
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Scheduled:</strong> [[${scheduledAt}]]
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #888888; font-size: 13px;">
+                    Booking ID: [[${bookingId}]]
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 20px; color: #777777; font-size: 14px; line-height: 22px;">
+              Log in to your account to browse other available services.
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding-top: 30px; font-size: 12px; color: #999999;">
+              &copy; 2026 Service Market Place. All rights reserved.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/packages/backend/service-marketplace/src/main/resources/templates/bookingCancelledProvider.html
+++ b/packages/backend/service-marketplace/src/main/resources/templates/bookingCancelledProvider.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Booking Cancelled</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f4f4f4; font-family: Arial, sans-serif;">
+
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td align="center" style="padding: 40px 20px;">
+
+        <table width="100%" cellpadding="0" cellspacing="0" border="0"
+               style="max-width: 500px; background-color: #ffffff; border-radius: 8px; padding: 40px;">
+
+          <tr>
+            <td align="center">
+              <h1 style="margin: 0; color: #333333;">Booking Cancelled</h1>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 20px; color: #555555; font-size: 16px; line-height: 24px;">
+              Hi <strong>[[${providerName}]]</strong>,
+              <br /><br />
+              <strong>[[${customerName}]]</strong> has cancelled their booking for <strong>[[${serviceTitle}]]</strong>. No payment was collected.
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 24px;">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0"
+                     style="background-color: #f8f8f8; border-radius: 6px; padding: 20px;">
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Service:</strong> [[${serviceTitle}]]
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #555555; font-size: 15px;">
+                    <strong>Scheduled:</strong> [[${scheduledAt}]]
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 6px 0; color: #888888; font-size: 13px;">
+                    Booking ID: [[${bookingId}]]
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <tr>
+            <td style="padding-top: 20px; color: #777777; font-size: 14px; line-height: 22px;">
+              Log in to your account to view your booking history.
+            </td>
+          </tr>
+
+          <tr>
+            <td align="center" style="padding-top: 30px; font-size: 12px; color: #999999;">
+              &copy; 2026 Service Market Place. All rights reserved.
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+
+</body>
+</html>

--- a/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/BookingServiceTest.java
+++ b/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/BookingServiceTest.java
@@ -179,7 +179,7 @@ class BookingServiceTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo("booking-123");
         assertThat(result.get(0).getCustomerName()).isEqualTo("Alice Student");
-        assertThat(result.get(0).getProviderName()).isEqualTo("Bob");
+        assertThat(result.get(0).getProviderName()).isEqualTo("Bob Smith");
         assertThat(result.get(0).getReviewerName()).isEqualTo("Alice Student");
         assertThat(result.get(0).getStatus()).isEqualTo(BookingStatus.CONFIRMED);
         verify(userRepository).findAllById(any());

--- a/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/BookingServiceTest.java
+++ b/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/BookingServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.Mockito;
@@ -84,6 +85,7 @@ class BookingServiceTest {
         mockProvider.setId("provider-456");
         mockProvider.setEmail("tutor@calpoly.edu");
         mockProvider.setFirstName("Bob");
+        mockProvider.setLastName("Smith");
         mockProvider.setStripeAccountId("acct_test_provider");
 
         lenient().when(userDetails.getUsername()).thenReturn("student@calpoly.edu");
@@ -230,32 +232,45 @@ class BookingServiceTest {
     // --- cancelBooking (JWT path) ---
 
     @Test
-    void cancelBooking_byCustomer_cancelsAndCleansUpStripeCustomer() {
+    void cancelBooking_byCustomer_cancelsAndNotifiesProvider() {
         Booking pending = buildAwaitingBooking();
 
         when(userRepository.findByEmail("student@calpoly.edu")).thenReturn(Optional.of(mockCustomer));
         when(bookingRepository.findById("booking-001")).thenReturn(Optional.of(pending));
         when(bookingRepository.save(any(Booking.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(userRepository.findById("provider-456")).thenReturn(Optional.of(mockProvider));
+        when(userRepository.findById("customer-789")).thenReturn(Optional.of(mockCustomer));
 
         BookingResponse result = bookingService.cancelBooking("booking-001", userDetails);
 
         assertThat(result.getStatus()).isEqualTo(BookingStatus.CANCELLED);
         verify(paymentService).cleanupStripeCustomer("cus_test_123");
+        verify(emailService).sendBookingCancelledProviderEmail(
+            eq("tutor@calpoly.edu"), eq("Bob"), eq("Alice Student"),
+            eq("Math Tutoring"), any(Instant.class), any()
+        );
     }
 
     @Test
-    void cancelBooking_byProvider_cancelsAndCleansUpStripeCustomer() {
+    void cancelBooking_byProvider_cancelsAndNotifiesCustomer() {
         Booking pending = buildAwaitingBooking();
 
         when(userDetails.getUsername()).thenReturn("tutor@calpoly.edu");
         when(userRepository.findByEmail("tutor@calpoly.edu")).thenReturn(Optional.of(mockProvider));
         when(bookingRepository.findById("booking-001")).thenReturn(Optional.of(pending));
         when(bookingRepository.save(any(Booking.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(userRepository.findById("customer-789")).thenReturn(Optional.of(mockCustomer));
+        when(userRepository.findById("provider-456")).thenReturn(Optional.of(mockProvider));
 
         BookingResponse result = bookingService.cancelBooking("booking-001", userDetails);
 
         assertThat(result.getStatus()).isEqualTo(BookingStatus.CANCELLED);
         verify(paymentService).cleanupStripeCustomer("cus_test_123");
+        verify(emailService, never()).sendBookingCancelledProviderEmail(any(), any(), any(), any(), any(), any());
+        verify(emailService).sendBookingCancelledCustomerEmail(
+            eq("student@calpoly.edu"), eq("Alice"), eq("Bob Smith"),
+            eq("Math Tutoring"), any(Instant.class), any()
+        );
     }
 
     @Test
@@ -272,9 +287,9 @@ class BookingServiceTest {
     }
 
     @Test
-    void cancelBooking_notAwaitingConfirmation_throwsBookingStateException() {
+    void cancelBooking_alreadyCancelled_throwsBookingStateException() {
         Booking booking = buildAwaitingBooking();
-        booking.setStatus(BookingStatus.CONFIRMED);
+        booking.setStatus(BookingStatus.CANCELLED);
 
         when(userRepository.findByEmail("student@calpoly.edu")).thenReturn(Optional.of(mockCustomer));
         when(bookingRepository.findById("booking-001")).thenReturn(Optional.of(booking));
@@ -307,18 +322,25 @@ class BookingServiceTest {
     }
 
     @Test
-    void processTokenAction_cancelToken_cancelsAndCleansUp() {
+    void processTokenAction_cancelToken_cancelsAndNotifiesCustomer() {
         Booking pending = buildAwaitingBooking();
 
         when(bookingTokenService.validateAndConsume("valid-cancel-token"))
             .thenReturn(new TokenResult("booking-001", BookingTokenAction.CANCEL));
         when(bookingRepository.findById("booking-001")).thenReturn(Optional.of(pending));
         when(bookingRepository.save(any(Booking.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(userRepository.findById("customer-789")).thenReturn(Optional.of(mockCustomer));
+        when(userRepository.findById("provider-456")).thenReturn(Optional.of(mockProvider));
 
         BookingTokenAction result = bookingService.processTokenAction("valid-cancel-token");
 
         assertThat(result).isEqualTo(BookingTokenAction.CANCEL);
         verify(paymentService).cleanupStripeCustomer("cus_test_123");
+        verify(emailService, never()).sendBookingCancelledProviderEmail(any(), any(), any(), any(), any(), any());
+        verify(emailService).sendBookingCancelledCustomerEmail(
+            eq("student@calpoly.edu"), eq("Alice"), eq("Bob Smith"),
+            eq("Math Tutoring"), any(Instant.class), any()
+        );
     }
 
     @Test

--- a/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/UserServiceTest.java
+++ b/packages/backend/service-marketplace/src/test/java/com/ServiceMarketplace/service_marketplace/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.ServiceMarketplace.service_marketplace;
 import com.ServiceMarketplace.service_marketplace.dto.AuthResponse;
 import com.ServiceMarketplace.service_marketplace.dto.RegisterRequest;
 import com.ServiceMarketplace.service_marketplace.exception.EmailAlreadyExistsException;
+import com.ServiceMarketplace.service_marketplace.exception.InvalidEmailDomainException;
 import com.ServiceMarketplace.service_marketplace.model.User;
 import com.ServiceMarketplace.service_marketplace.repository.UserRepository;
 import com.ServiceMarketplace.service_marketplace.service.EmailService;
@@ -52,7 +53,7 @@ public class UserServiceTest {
     @Test
     void registerUser_success() {
         RegisterRequest request = new RegisterRequest();
-        request.setEmail("test@university.edu");
+        request.setEmail("test@calpoly.edu");
         request.setPassword("password123");
 
         when(userRepository.existsByEmail(request.getEmail())).thenReturn(false);
@@ -67,7 +68,7 @@ public class UserServiceTest {
 
         AuthResponse response = userService.registerUser(request);
 
-        assertEquals("test@university.edu", response.getEmail());
+        assertEquals("test@calpoly.edu", response.getEmail());
         assertEquals("abc123", response.getId());
         assertEquals("jwt-token", response.getToken());
         verify(verificationService).createVerification(request.getEmail(), "123456");
@@ -78,12 +79,23 @@ public class UserServiceTest {
     @Test
     void registerUser_duplicateEmail_throwsException() {
         RegisterRequest request = new RegisterRequest();
-        request.setEmail("test@university.edu");
+        request.setEmail("test@calpoly.edu");
         request.setPassword("password123");
 
         when(userRepository.existsByEmail(request.getEmail())).thenReturn(true);
 
         assertThrows(EmailAlreadyExistsException.class, () -> userService.registerUser(request));
         verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void registerUser_nonCalPolyEmail_throwsInvalidEmailDomainException() {
+        RegisterRequest request = new RegisterRequest();
+        request.setEmail("test@gmail.com");
+        request.setPassword("password123");
+
+        assertThrows(InvalidEmailDomainException.class, () -> userService.registerUser(request));
+        verify(userRepository, never()).save(any(User.class));
+        verify(userRepository, never()).existsByEmail(any());
     }
 }


### PR DESCRIPTION
## Summary
- Emails the provider when a customer cancels a booking
- Emails the customer when a provider cancels (JWT path or email token link)
- Broadened cancellation to allow any non-cancelled booking status — cancelling an already-confirmed booking does not currently issue a refund

## Note
Refund handling for confirmed bookings cancelled post-payment is not included here and needs to be addressed in a separate ticket before this flow is production-ready.